### PR TITLE
remove rule for reference amount calculator

### DIFF
--- a/Adapter/PlentymarketsAdapter/Helper/ReferenceAmountCalculator.php
+++ b/Adapter/PlentymarketsAdapter/Helper/ReferenceAmountCalculator.php
@@ -64,12 +64,6 @@ class ReferenceAmountCalculator implements ReferenceAmountCalculatorInterface
 
         $modifier = self::$conversionMatrix[$variationUnit]['conversion'];
 
-        $content = $variation['unit']['content'] * $modifier;
-
-        if ($content <= 0.25 && 5 !== $variation['unit']['unitId'] && 2 !== $variation['unit']['unitId']) {
-            return 0.1 / $modifier;
-        }
-
         return 1.0 / $modifier;
     }
 


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

This PR remove the rule for unit mililiter and miligram < 0.25 since §11 PAngV.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix