### PR TITLE
fix variation unit mapping

### DIFF
--- a/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
+++ b/Adapter/PlentymarketsAdapter/ResponseParser/Product/Variation/VariationResponseParser.php
@@ -147,6 +147,10 @@ class VariationResponseParser implements VariationResponseParserInterface
                 PlentymarketsAdapter::NAME,
                 Variation::TYPE
             );
+            
+            if (empty($variation['unit'])) {
+                $variation['unit'] = $mainVariation['unit'];
+            }
 
             $variationObject = new Variation();
             $variationObject->setIdentifier($identity->getObjectIdentifier());


### PR DESCRIPTION
| Q                         | A
| ------------------------- | ---
| issue or Enhancement      | issue
| Changelog updated?        | no
| License                   | MIT


#### What's in this PR?

This PR fixed an issue, if a variation has not a selected unit. So plenty should give the set unit of the main variation. But the section "unit" is empty in the response. This fix take the unit settings of the main variation, if the child variation has not set an unit.


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix